### PR TITLE
Add `compare_to` method to `Stamp`

### DIFF
--- a/src/pyitc/pyitc.py
+++ b/src/pyitc/pyitc.py
@@ -189,7 +189,7 @@ class Stamp(_wrappers.ItcWrapper):
         return self
 
     def compare_to(self: Self, other_stamp: Stamp) -> _wrappers.StampComparisonResult:
-        """Compare the Stamp with another Stamp
+        """Compare the Stamp to another Stamp.
 
         :param other_stamp: The Stamp to compare with
         :type other_stamp: Stamp
@@ -197,7 +197,7 @@ class Stamp(_wrappers.ItcWrapper):
         :rtype: StampComparisonResult
         :raises ItcError: If something goes wrong during the comparison
         """
-        return _wrappers.compare_stamps(self._c_type, other_stamp._c_type)
+        return _wrappers.compare_stamps(self._c_type, other_stamp._c_type)  # noqa: SLF001
 
     def __str__(self: Self) -> str:
         """Serialise a Stamp to string."""
@@ -215,9 +215,7 @@ class Stamp(_wrappers.ItcWrapper):
         if not isinstance(other, Stamp):  # pragma: no cover
             return NotImplemented
 
-        return (
-            self.compare_to(other) == _wrappers.StampComparisonResult.LESS_THAN
-        )
+        return self.compare_to(other) == _wrappers.StampComparisonResult.LESS_THAN
 
     def __le__(self: Self, other: object) -> bool:
         """Check if the Stamp is less than another Stamp."""
@@ -237,10 +235,7 @@ class Stamp(_wrappers.ItcWrapper):
         if not isinstance(other, Stamp):  # pragma: no cover
             return NotImplemented
 
-        return (
-            self.compare_to(other)
-            == _wrappers.StampComparisonResult.GREATER_THAN
-        )
+        return self.compare_to(other) == _wrappers.StampComparisonResult.GREATER_THAN
 
     def __ge__(self: Self, other: object) -> bool:
         """Check if the Stamp is greater than or equal to another Stamp."""
@@ -260,10 +255,7 @@ class Stamp(_wrappers.ItcWrapper):
         if not isinstance(other, Stamp):  # pragma: no cover
             return NotImplemented
 
-        return (
-            self.compare_to(other)
-            == _wrappers.StampComparisonResult.EQUAL
-        )
+        return self.compare_to(other) == _wrappers.StampComparisonResult.EQUAL
 
     def __ne__(self: Self, other: object) -> bool:
         """Check if the Stamp is not equal to another Stamp."""

--- a/src/pyitc/pyitc.py
+++ b/src/pyitc/pyitc.py
@@ -188,6 +188,17 @@ class Stamp(_wrappers.ItcWrapper):
 
         return self
 
+    def compare_to(self: Self, other_stamp: Stamp) -> _wrappers.StampComparisonResult:
+        """Compare the Stamp with another Stamp
+
+        :param other_stamp: The Stamp to compare with
+        :type other_stamp: Stamp
+        :returns: The result of the comparison
+        :rtype: StampComparisonResult
+        :raises ItcError: If something goes wrong during the comparison
+        """
+        return _wrappers.compare_stamps(self._c_type, other_stamp._c_type)
+
     def __str__(self: Self) -> str:
         """Serialise a Stamp to string."""
         try:
@@ -205,8 +216,7 @@ class Stamp(_wrappers.ItcWrapper):
             return NotImplemented
 
         return (
-            _wrappers.compare_stamps(self._c_type, other._c_type)
-            == _wrappers.StampComparisonResult.LESS_THAN
+            self.compare_to(other) == _wrappers.StampComparisonResult.LESS_THAN
         )
 
     def __le__(self: Self, other: object) -> bool:
@@ -215,7 +225,7 @@ class Stamp(_wrappers.ItcWrapper):
             return NotImplemented
 
         return bool(
-            _wrappers.compare_stamps(self._c_type, other._c_type)
+            self.compare_to(other)
             & (
                 _wrappers.StampComparisonResult.LESS_THAN
                 | _wrappers.StampComparisonResult.EQUAL
@@ -228,7 +238,7 @@ class Stamp(_wrappers.ItcWrapper):
             return NotImplemented
 
         return (
-            _wrappers.compare_stamps(self._c_type, other._c_type)
+            self.compare_to(other)
             == _wrappers.StampComparisonResult.GREATER_THAN
         )
 
@@ -238,7 +248,7 @@ class Stamp(_wrappers.ItcWrapper):
             return NotImplemented
 
         return bool(
-            _wrappers.compare_stamps(self._c_type, other._c_type)
+            self.compare_to(other)
             & (
                 _wrappers.StampComparisonResult.GREATER_THAN
                 | _wrappers.StampComparisonResult.EQUAL
@@ -251,7 +261,7 @@ class Stamp(_wrappers.ItcWrapper):
             return NotImplemented
 
         return (
-            _wrappers.compare_stamps(self._c_type, other._c_type)
+            self.compare_to(other)
             == _wrappers.StampComparisonResult.EQUAL
         )
 
@@ -261,7 +271,7 @@ class Stamp(_wrappers.ItcWrapper):
             return NotImplemented
 
         return bool(
-            _wrappers.compare_stamps(self._c_type, other._c_type)
+            self.compare_to(other)
             & (
                 _wrappers.StampComparisonResult.CONCURRENT
                 | _wrappers.StampComparisonResult.LESS_THAN


### PR DESCRIPTION
Add `compare_to` method to `Stamp`. This makes it easier to check for specific relationships between stamps