### PR TITLE
Add `StampComparisonResult` to the public API

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -122,6 +122,7 @@ python.install_sources(
         'src' / 'pyitc' / 'extended_api.py',
         'src' / 'pyitc' / 'pyitc.py',
         'src' / 'pyitc' / 'exceptions.py',
+        'src' / 'pyitc' / 'util.py',
     ]),
     subdir: meson.project_name(),
 )

--- a/src/pyitc/__init__.py
+++ b/src/pyitc/__init__.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 from types import MappingProxyType
 
-from pyitc.pyitc import Stamp
+from pyitc.pyitc import Stamp, StampComparisonResult
 
 from ._internals import _lib
 
 __all__ = [
     "SUPPORTED_FEATURES",
     "Stamp",
+    "StampComparisonResult",
 ]
 
 SUPPORTED_FEATURES: MappingProxyType[str, bool] = MappingProxyType(

--- a/src/pyitc/__init__.py
+++ b/src/pyitc/__init__.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 
 from types import MappingProxyType
 
-from pyitc.pyitc import Stamp, StampComparisonResult
+from pyitc.pyitc import Stamp
+from pyitc.util import StampComparisonResult
 
 from ._internals import _lib
 

--- a/src/pyitc/_internals/wrappers.py
+++ b/src/pyitc/_internals/wrappers.py
@@ -10,7 +10,7 @@ from sys import version_info
 from typing import TYPE_CHECKING, Any, Callable
 
 from pyitc.exceptions import ItcCApiError, ItcStatus, UnknownError
-from pyitc import StampComparisonResult
+from pyitc.util import StampComparisonResult
 
 from . import _ffi, _lib
 

--- a/src/pyitc/_internals/wrappers.py
+++ b/src/pyitc/_internals/wrappers.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from contextlib import suppress
-from enum import IntEnum
 from sys import version_info
 from typing import TYPE_CHECKING, Any, Callable
 
 from pyitc.exceptions import ItcCApiError, ItcStatus, UnknownError
+from pyitc import StampComparisonResult
 
 from . import _ffi, _lib
 
@@ -21,15 +21,6 @@ else:  # pragma: no cover
 
 if TYPE_CHECKING:  # pragma: no cover
     from cffi.backend_ctypes import CTypesData  # type: ignore[import-untyped]
-
-
-class StampComparisonResult(IntEnum):
-    """The ITC Stamp comparison result returned from the C API."""
-
-    LESS_THAN = _lib.ITC_STAMP_COMPARISON_LESS_THAN
-    GREATER_THAN = _lib.ITC_STAMP_COMPARISON_GREATER_THAN
-    EQUAL = _lib.ITC_STAMP_COMPARISON_EQUAL
-    CONCURRENT = _lib.ITC_STAMP_COMPARISON_CONCURRENT
 
 
 class ItcWrapper(ABC):

--- a/src/pyitc/pyitc.py
+++ b/src/pyitc/pyitc.py
@@ -5,8 +5,11 @@
 
 from __future__ import annotations
 
+from enum import IntEnum
 from sys import version_info
 from typing import TYPE_CHECKING, Any
+
+from ._internals import _lib
 
 from . import extended_api
 from ._internals import wrappers as _wrappers
@@ -21,6 +24,15 @@ if TYPE_CHECKING:  # pragma: no cover
     from cffi.backend_ctypes import (  # type: ignore[import-untyped]
         CTypesData as _CTypesData,
     )
+
+
+class StampComparisonResult(IntEnum):
+    """The ITC Stamp comparison result returned from the C API."""
+
+    LESS_THAN = _lib.ITC_STAMP_COMPARISON_LESS_THAN
+    GREATER_THAN = _lib.ITC_STAMP_COMPARISON_GREATER_THAN
+    EQUAL = _lib.ITC_STAMP_COMPARISON_EQUAL
+    CONCURRENT = _lib.ITC_STAMP_COMPARISON_CONCURRENT
 
 
 class Stamp(_wrappers.ItcWrapper):
@@ -188,7 +200,7 @@ class Stamp(_wrappers.ItcWrapper):
 
         return self
 
-    def compare_to(self: Self, other_stamp: Stamp) -> _wrappers.StampComparisonResult:
+    def compare_to(self: Self, other_stamp: Stamp) -> StampComparisonResult:
         """Compare the Stamp to another Stamp.
 
         :param other_stamp: The Stamp to compare with
@@ -215,7 +227,7 @@ class Stamp(_wrappers.ItcWrapper):
         if not isinstance(other, Stamp):  # pragma: no cover
             return NotImplemented
 
-        return self.compare_to(other) == _wrappers.StampComparisonResult.LESS_THAN
+        return self.compare_to(other) == StampComparisonResult.LESS_THAN
 
     def __le__(self: Self, other: object) -> bool:
         """Check if the Stamp is less than another Stamp."""
@@ -225,8 +237,8 @@ class Stamp(_wrappers.ItcWrapper):
         return bool(
             self.compare_to(other)
             & (
-                _wrappers.StampComparisonResult.LESS_THAN
-                | _wrappers.StampComparisonResult.EQUAL
+                StampComparisonResult.LESS_THAN
+                | StampComparisonResult.EQUAL
             )
         )
 
@@ -235,7 +247,7 @@ class Stamp(_wrappers.ItcWrapper):
         if not isinstance(other, Stamp):  # pragma: no cover
             return NotImplemented
 
-        return self.compare_to(other) == _wrappers.StampComparisonResult.GREATER_THAN
+        return self.compare_to(other) == StampComparisonResult.GREATER_THAN
 
     def __ge__(self: Self, other: object) -> bool:
         """Check if the Stamp is greater than or equal to another Stamp."""
@@ -245,8 +257,8 @@ class Stamp(_wrappers.ItcWrapper):
         return bool(
             self.compare_to(other)
             & (
-                _wrappers.StampComparisonResult.GREATER_THAN
-                | _wrappers.StampComparisonResult.EQUAL
+                StampComparisonResult.GREATER_THAN
+                | StampComparisonResult.EQUAL
             )
         )
 
@@ -255,7 +267,7 @@ class Stamp(_wrappers.ItcWrapper):
         if not isinstance(other, Stamp):  # pragma: no cover
             return NotImplemented
 
-        return self.compare_to(other) == _wrappers.StampComparisonResult.EQUAL
+        return self.compare_to(other) == StampComparisonResult.EQUAL
 
     def __ne__(self: Self, other: object) -> bool:
         """Check if the Stamp is not equal to another Stamp."""
@@ -265,9 +277,9 @@ class Stamp(_wrappers.ItcWrapper):
         return bool(
             self.compare_to(other)
             & (
-                _wrappers.StampComparisonResult.CONCURRENT
-                | _wrappers.StampComparisonResult.LESS_THAN
-                | _wrappers.StampComparisonResult.GREATER_THAN
+                StampComparisonResult.CONCURRENT
+                | StampComparisonResult.LESS_THAN
+                | StampComparisonResult.GREATER_THAN
             )
         )
 

--- a/src/pyitc/pyitc.py
+++ b/src/pyitc/pyitc.py
@@ -236,10 +236,7 @@ class Stamp(_wrappers.ItcWrapper):
 
         return bool(
             self.compare_to(other)
-            & (
-                StampComparisonResult.LESS_THAN
-                | StampComparisonResult.EQUAL
-            )
+            & (StampComparisonResult.LESS_THAN | StampComparisonResult.EQUAL)
         )
 
     def __gt__(self: Self, other: object) -> bool:
@@ -256,10 +253,7 @@ class Stamp(_wrappers.ItcWrapper):
 
         return bool(
             self.compare_to(other)
-            & (
-                StampComparisonResult.GREATER_THAN
-                | StampComparisonResult.EQUAL
-            )
+            & (StampComparisonResult.GREATER_THAN | StampComparisonResult.EQUAL)
         )
 
     def __eq__(self: Self, other: object) -> bool:

--- a/src/pyitc/pyitc.py
+++ b/src/pyitc/pyitc.py
@@ -5,15 +5,13 @@
 
 from __future__ import annotations
 
-from enum import IntEnum
 from sys import version_info
 from typing import TYPE_CHECKING, Any
-
-from ._internals import _lib
 
 from . import extended_api
 from ._internals import wrappers as _wrappers
 from .exceptions import InactiveStampError, ItcError
+from .util import StampComparisonResult
 
 if version_info < (3, 11):  # pragma: no cover
     from typing_extensions import Self
@@ -24,15 +22,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from cffi.backend_ctypes import (  # type: ignore[import-untyped]
         CTypesData as _CTypesData,
     )
-
-
-class StampComparisonResult(IntEnum):
-    """The ITC Stamp comparison result returned from the C API."""
-
-    LESS_THAN = _lib.ITC_STAMP_COMPARISON_LESS_THAN
-    GREATER_THAN = _lib.ITC_STAMP_COMPARISON_GREATER_THAN
-    EQUAL = _lib.ITC_STAMP_COMPARISON_EQUAL
-    CONCURRENT = _lib.ITC_STAMP_COMPARISON_CONCURRENT
 
 
 class Stamp(_wrappers.ItcWrapper):

--- a/src/pyitc/util.py
+++ b/src/pyitc/util.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2024 pyitc project. Released under AGPL-3.0
+# license. Refer to the LICENSE file for details or visit:
+# https://www.gnu.org/licenses/agpl-3.0.en.html
+"""Utilities."""
+
+from enum import IntEnum
+
+from ._internals import _lib
+
+
+class StampComparisonResult(IntEnum):
+    """The ITC Stamp comparison result returned from the C API."""
+
+    LESS_THAN = _lib.ITC_STAMP_COMPARISON_LESS_THAN
+    GREATER_THAN = _lib.ITC_STAMP_COMPARISON_GREATER_THAN
+    EQUAL = _lib.ITC_STAMP_COMPARISON_EQUAL
+    CONCURRENT = _lib.ITC_STAMP_COMPARISON_CONCURRENT


### PR DESCRIPTION
Add `StampComparisonResult` to the public API, so it can be used to compare the result of the `Stamp.compare_to` method.